### PR TITLE
multiview: Add option to swap left/right stereo channels (UI only)

### DIFF
--- a/blender/release/scripts/startup/bl_ui/space_userpref.py
+++ b/blender/release/scripts/startup/bl_ui/space_userpref.py
@@ -461,9 +461,15 @@ class USERPREF_PT_system(Panel):
 
         if system.stereo_display == 'ANAGLYPH':
             col.prop(system, "anaglyph_type", text="Type")
+            if system.anaglyph_type == 'GREEN_MAGENTA':
+                col.prop(system, "anaglyph_swap_left_right", text="Swap Left/Right")
 
         if system.stereo_display == 'INTERLACE':
             col.prop(system, "interlace_type", text="Type")
+            col.prop(system, "interlace_swap_left_right", text="Swap Left/Right")
+
+        if system.stereo_display == 'SIDEBYSIDE':
+            col.prop(system, "sidebyside_swap_left_right", text="Swap Left/Right")
 
         # 2. Column
         column = split.column()

--- a/blender/source/blender/makesdna/DNA_userdef_types.h
+++ b/blender/source/blender/makesdna/DNA_userdef_types.h
@@ -466,10 +466,11 @@ typedef struct UserDef {
 	float sculpt_paint_overlay_col[3];
 
 	short tweak_threshold;
+	short stereo_flag;
 	char stereo_display; /* stereo method for the user display */
 	char anaglyph_type; /* anaglyph scheme for the user display */
 	char interlace_type;  /* interlace type for the user display */
-	char pad3[7];
+	char pad3[5];
 
 	char author[80];	/* author name for file formats supporting it */
 
@@ -774,6 +775,13 @@ typedef enum eStereoDisplayMode {
 	USER_STEREO_DISPLAY_INTERLACE   = 6,
 	USER_STEREO_DISPLAY_BLURAY      = 7,
 } eStereoDisplayMode;
+
+/* UserDef.stereo_flag */
+typedef enum eStereoFlag {
+	USER_ANAGLYPH_SWAP_LEFT_RIGHT	= (1 << 1),
+	USER_INTERLACE_SWAP_LEFT_RIGHT	= (1 << 2),
+	USER_SIDEBYSIDE_SWAP_LEFT_RIGHT	= (1 << 3),
+} eStereoFlag;
 
 /* UserDef.anaglyph_type */
 typedef enum eAnaglyphType {

--- a/blender/source/blender/makesrna/intern/rna_userdef.c
+++ b/blender/source/blender/makesrna/intern/rna_userdef.c
@@ -3670,10 +3670,25 @@ static void rna_def_userdef_system(BlenderRNA *brna)
 	RNA_def_property_ui_text(prop, "Anaglyph Type", "");
 	RNA_def_property_update(prop, NC_SPACE | ND_SPACE_PROPERTIES, NULL);
 
+	prop = RNA_def_property(srna, "anaglyph_swap_left_right", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "stereo_flag", USER_ANAGLYPH_SWAP_LEFT_RIGHT);
+	RNA_def_property_ui_text(prop, "Swap Left/Right", "Swap left and right stereo channels");
+	RNA_def_property_update(prop, NC_SPACE | ND_SPACE_PROPERTIES | NC_IMAGE, NULL);
+
 	prop = RNA_def_property(srna, "interlace_type", PROP_ENUM, PROP_NONE);
 	RNA_def_property_enum_items(prop, interlace_type_items);
 	RNA_def_property_ui_text(prop, "Interlace Type", "");
 	RNA_def_property_update(prop, NC_SPACE | ND_SPACE_PROPERTIES, NULL);
+
+	prop = RNA_def_property(srna, "interlace_swap_left_right", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "stereo_flag", USER_INTERLACE_SWAP_LEFT_RIGHT);
+	RNA_def_property_ui_text(prop, "Swap Left/Right", "Swap left and right stereo channels");
+	RNA_def_property_update(prop, NC_SPACE | ND_SPACE_PROPERTIES | NC_IMAGE, NULL);
+
+	prop = RNA_def_property(srna, "sidebyside_swap_left_right", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "stereo_flag", USER_SIDEBYSIDE_SWAP_LEFT_RIGHT);
+	RNA_def_property_ui_text(prop, "Swap Left/Right", "Swap left and right stereo channels (enable for cross-eyed stereo viewing)");
+	RNA_def_property_update(prop, NC_SPACE | ND_SPACE_PROPERTIES | NC_IMAGE, NULL);
 
 #ifdef WITH_CYCLES
 	prop = RNA_def_property(srna, "compute_device_type", PROP_ENUM, PROP_NONE);


### PR DESCRIPTION
"Interlace", "Side-By-Side" and "Anaglyph" each have its own "swap left/right" option so user can, for example, quickly switch between cross-eyed "Side-By-Side" and typical anaglyph scheme. For anaglyph the option only available for green-magenta because it does not make sense for other schemes.

Signed-off-by: Alexey Akishin alex@science.su
