### PR TITLE
User preference 3D display options tweaks

### DIFF
--- a/blender/release/scripts/startup/bl_ui/space_userpref.py
+++ b/blender/release/scripts/startup/bl_ui/space_userpref.py
@@ -403,7 +403,7 @@ class USERPREF_PT_system(Panel):
         col.separator()
         col.separator()
 
-        col.label(text="3D Display:")
+        col.label(text="3D Stereo Display:")
         col.prop(system, "stereo_display", text="")
 
         if system.stereo_display == 'ANAGLYPH':

--- a/blender/source/blender/makesdna/DNA_userdef_types.h
+++ b/blender/source/blender/makesdna/DNA_userdef_types.h
@@ -769,14 +769,13 @@ typedef enum eImageDrawMethod {
 
 /* UserDef.stereo_display */
 typedef enum eStereoDisplayMode {
-	S3D_DISPLAY_NONE        = 0,
-	S3D_DISPLAY_SIDEBYSIDE  = 1,
-	S3D_DISPLAY_TOPBOTTOM   = 2,
-	S3D_DISPLAY_PAGEFLIP    = 3,
-	S3D_DISPLAY_ANAGLYPH    = 4,
-	S3D_DISPLAY_EPILEPSY    = 5,
-	S3D_DISPLAY_INTERLACE   = 6,
-	S3D_DISPLAY_BLURAY      = 7,
+	S3D_DISPLAY_ANAGLYPH    = 0,
+	/* S3D_DISPLAY_BLURAY      = 1, */
+	S3D_DISPLAY_EPILEPSY    = 2,
+	S3D_DISPLAY_INTERLACE   = 3,
+	S3D_DISPLAY_PAGEFLIP    = 4,
+	S3D_DISPLAY_SIDEBYSIDE  = 5,
+	S3D_DISPLAY_TOPBOTTOM   = 6,
 } eStereoDisplayMode;
 
 /* UserDef.stereo_flag */

--- a/blender/source/blender/makesrna/intern/rna_userdef.c
+++ b/blender/source/blender/makesrna/intern/rna_userdef.c
@@ -3396,9 +3396,8 @@ static void rna_def_userdef_system(BlenderRNA *brna)
 	};
 
 	static EnumPropertyItem stereo_display_items[] = {
-		{S3D_DISPLAY_NONE, "NONE", 0, "None", ""},
 		{S3D_DISPLAY_ANAGLYPH, "ANAGLYPH", 0, "Anaglyph", ""},
-//		{S3D_DISPLAY_BLURAY, "BLURAY", 0, "Bluray", ""},
+/*		{S3D_DISPLAY_BLURAY, "BLURAY", 0, "Bluray", ""}, */
 		{S3D_DISPLAY_EPILEPSY, "EPILEPSY", 0, "Dr. Epilepsy", ""},
 		{S3D_DISPLAY_INTERLACE, "INTERLACE", 0, "Interlace", ""},
 		{S3D_DISPLAY_PAGEFLIP, "TIMESEQUENTIAL", 0, "Time Sequential", "Renders alternate eyes (also known as pageflip). It requires Quadbuffer support in the graphic card"},

--- a/blender/source/blender/render/intern/source/pipeline.c
+++ b/blender/source/blender/render/intern/source/pipeline.c
@@ -207,9 +207,6 @@ int RE_HasFakeLayer(RenderResult *res)
 
 int RE_HasStereo3D(RenderResult *res)
 {
-	if (U.stereo_display == S3D_DISPLAY_NONE)
-		return FALSE;
-
 	if (! BLI_findstring(&res->views, STEREO_LEFT_NAME, offsetof(RenderView, name)))
 		return FALSE;
 

--- a/blender/source/blender/windowmanager/intern/wm_draw.c
+++ b/blender/source/blender/windowmanager/intern/wm_draw.c
@@ -1049,8 +1049,7 @@ void wm_draw_update(bContext *C)
 				wm_method_draw_overlap_all(C, win, 1);
 			else // if (drawmethod == USER_DRAW_TRIPLE)
 			{
-				if (U.stereo_display == S3D_DISPLAY_NONE ||
-					((win->flag & WM_STEREO)== FALSE))
+				if( (win->flag & WM_STEREO) == FALSE)
 					wm_method_draw_triple(C, win);
 				else {
 					wm_method_draw_triple_stereo(C, win, STEREO_LEFT_ID);

--- a/blender/source/blender/windowmanager/intern/wm_stereo.c
+++ b/blender/source/blender/windowmanager/intern/wm_stereo.c
@@ -403,11 +403,8 @@ int wm_stereo_toggle_exec(bContext *C, wmOperator *op)
 	/* toggle per window stereo setting */
 	win->flag ^= WM_STEREO;
 
-	if ((win->flag & WM_STEREO) && U.stereo_display == S3D_DISPLAY_NONE)
-		BKE_reportf(op->reports, RPT_WARNING, "No 3D display mode set in User Preferences");
-
 	/* pagelfip requires a new window to be created with the proper OS flags */
-	else if (U.stereo_display == S3D_DISPLAY_PAGEFLIP) {
+	if (U.stereo_display == S3D_DISPLAY_PAGEFLIP) {
 		if (wm_window_duplicate_exec(C, op) == OPERATOR_FINISHED) {
 			wm_window_close(C, wm, win);
 			win = (wmWindow *)wm->windows.last;


### PR DESCRIPTION
- Change label in the user preferences to "3D Stereo Display" because we support only stereo displays at the moment
- Remove "None" 3D Stereo Display
- Rearrange items in eStereoDisplayMode to alphabetical order (the same order they are in rna_userdef.c)
- Anaglyph became the default; I think this is good default because I guess this is the most popular method for viewing 3D stereo on typical computer monitor
- Some small cleanups: change one //-style comment to /*-style (because this is what's used in other places to comment out EnumPropertyItem lines), comment out S3D_DISPLAY_BLURAY in eStereoDisplayMode enum

Resolves #41
