### PR TITLE
Implement non-squeezed side-by-side mode

### DIFF
--- a/blender/release/scripts/startup/bl_ui/space_userpref.py
+++ b/blender/release/scripts/startup/bl_ui/space_userpref.py
@@ -417,6 +417,7 @@ class USERPREF_PT_system(Panel):
             col.prop(system, "use_stereo_interlace_swap")
 
         if system.stereo_display == 'SIDEBYSIDE':
+            col.prop(system, "use_stereo_sidebyside_fullwidth")
             col.prop(system, "use_stereo_sidebyside_crosseyed")
 
         # 2. Column

--- a/blender/source/blender/editors/screen/screen_edit.c
+++ b/blender/source/blender/editors/screen/screen_edit.c
@@ -1109,7 +1109,7 @@ void ED_screen_refresh(wmWindowManager *wm, wmWindow *win)
 		rcti winrct;
 	
 		winrct.xmin = 0;
-		winrct.xmax = WM_window_pixels_x(win) - 1;
+		winrct.xmax = WM_stereo_window_pixels_x(win) - 1;
 		winrct.ymin = 0;
 		winrct.ymax = WM_window_pixels_y(win) - 1;
 		

--- a/blender/source/blender/makesdna/DNA_userdef_types.h
+++ b/blender/source/blender/makesdna/DNA_userdef_types.h
@@ -782,6 +782,7 @@ typedef enum eStereoDisplayMode {
 typedef enum eStereoFlag {
 	S3D_INTERLACE_SWAP        = (1 << 0),
 	S3D_SIDEBYSIDE_CROSSEYED  = (1 << 1),
+	S3D_SIDEBYSIDE_FULLWIDTH  = (1 << 2),
 } eStereoFlag;
 
 /* UserDef.stereo_anaglyph_type */

--- a/blender/source/blender/makesrna/intern/rna_userdef.c
+++ b/blender/source/blender/makesrna/intern/rna_userdef.c
@@ -3702,6 +3702,11 @@ static void rna_def_userdef_system(BlenderRNA *brna)
 	RNA_def_property_ui_text(prop, "Cross-Eyed", "Right eye should see left image and vice-versa");
 	RNA_def_property_update(prop, NC_SPACE | ND_SPACE_PROPERTIES | NC_IMAGE, NULL);
 
+	prop = RNA_def_property(srna, "use_stereo_sidebyside_fullwidth", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "stereo_flag", S3D_SIDEBYSIDE_FULLWIDTH);
+	RNA_def_property_ui_text(prop, "Full Width", "Useful for freeviewing in small window or viewing in full-screen with prismatic glasses or one-eye stereoscope");
+	RNA_def_property_update(prop, NC_SPACE | ND_SPACE_PROPERTIES | NC_IMAGE, NULL);
+
 #ifdef WITH_CYCLES
 	prop = RNA_def_property(srna, "compute_device_type", PROP_ENUM, PROP_NONE);
 	RNA_def_property_flag(prop, PROP_ENUM_NO_CONTEXT);

--- a/blender/source/blender/windowmanager/WM_api.h
+++ b/blender/source/blender/windowmanager/WM_api.h
@@ -97,6 +97,7 @@ void		WM_check			(struct bContext *C);
 struct wmWindow	*WM_window_open	(struct bContext *C, struct rcti *rect);
 
 int			WM_window_pixels_x		(struct wmWindow *win);
+int			WM_stereo_window_pixels_x	(struct wmWindow *win);
 int			WM_window_pixels_y		(struct wmWindow *win);
 
 /* defines for 'type' WM_window_open_temp */

--- a/blender/source/blender/windowmanager/intern/wm_stereo.c
+++ b/blender/source/blender/windowmanager/intern/wm_stereo.c
@@ -218,7 +218,7 @@ static void wm_method_draw_stereo_sidebyside(wmWindow *win)
 		drawdata = BLI_findlink(&win->drawdata, (view * 2) + 1);
 		triple = drawdata->triple;
 
-		soffx = WM_window_pixels_x(win) * 0.5;
+		soffx = WM_stereo_window_pixels_x(win) * 0.5;
 		if (view == STEREO_LEFT_ID) {
 			if(!cross_eyed)
 				soffx = 0;
@@ -232,11 +232,13 @@ static void wm_method_draw_stereo_sidebyside(wmWindow *win)
 
 		for (y = 0, offy = 0; y < triple->ny; offy += triple->y[y], y++) {
 			for (x = 0, offx = 0; x < triple->nx; offx += triple->x[x], x++) {
-				sizex = (x == triple->nx - 1) ? WM_window_pixels_x(win) - offx : triple->x[x];
+				sizex = (x == triple->nx - 1) ? WM_stereo_window_pixels_x(win) - offx : triple->x[x];
 				sizey = (y == triple->ny - 1) ? WM_window_pixels_y(win) - offy : triple->y[y];
 
 				/* wmOrtho for the screen has this same offset */
 				ratiox = sizex;
+				if(U.stereo_flag & S3D_SIDEBYSIDE_FULLWIDTH)
+					ratiox /= 2;
 				ratioy = sizey;
 				halfx = GLA_PIXEL_OFS;
 				halfy = GLA_PIXEL_OFS;

--- a/blender/source/blender/windowmanager/intern/wm_subwindow.c
+++ b/blender/source/blender/windowmanager/intern/wm_subwindow.c
@@ -218,8 +218,8 @@ void wm_subwindow_position(wmWindow *win, int swinid, rcti *winrct)
 		 * fixed it). - zr  (2001!)
 		 */
 		
-		if (swin->winrct.xmax > WM_window_pixels_x(win))
-			swin->winrct.xmax = WM_window_pixels_x(win);
+		if (swin->winrct.xmax > WM_stereo_window_pixels_x(win) )
+			swin->winrct.xmax = WM_stereo_window_pixels_x(win);
 		if (swin->winrct.ymax > WM_window_pixels_y(win))
 			swin->winrct.ymax = WM_window_pixels_y(win);
 		

--- a/blender/source/blender/windowmanager/intern/wm_window.c
+++ b/blender/source/blender/windowmanager/intern/wm_window.c
@@ -1397,6 +1397,14 @@ float WM_cursor_pressure(const struct wmWindow *win)
 /* mac retina opens window in size X, but it has up to 2 x more pixels */
 int WM_window_pixels_x(wmWindow *win)
 {
+	if( (U.stereo_flag & S3D_SIDEBYSIDE_FULLWIDTH) && (win->flag & WM_STEREO) )
+		return WM_stereo_window_pixels_x(win) / 2;
+	else
+		return WM_stereo_window_pixels_x(win);
+}
+
+int WM_stereo_window_pixels_x(wmWindow *win)
+{
 	float f = GHOST_GetNativePixelSize(win->ghostwin);
 	
 	return (int)(f * (float)win->sizex);


### PR DESCRIPTION
This patch resolves #44. However, it currently does not automatically send "resize" event to Blender, so after pressing "d" to enable/disable stereo 3D (or after toggling "Full Width" when stereo 3D already enabled) you need to resize Blender window by at least 1 pixel (or toggle/untoggle fullscreen). I did not figured out yet how to send Blender "resize" event (without resorting to changing window size). Perhaps you have an idea?
