### PR TITLE
multiview: moving most functions to use viewname instead of view_id

### DIFF
--- a/blender/intern/cycles/blender/blender_session.cpp
+++ b/blender/intern/cycles/blender/blender_session.cpp
@@ -251,9 +251,9 @@ static PassType get_pass_type(BL::RenderPass b_pass)
 	return PASS_NONE;
 }
 
-static BL::RenderResult begin_render_result(BL::RenderEngine b_engine, int x, int y, int w, int h, const char *layername, int view)
+static BL::RenderResult begin_render_result(BL::RenderEngine b_engine, int x, int y, int w, int h, const char *layername, const char *viewname)
 {
-	return b_engine.begin_result(x, y, w, h, layername, view);
+	return b_engine.begin_result(x, y, w, h, layername, viewname);
 }
 
 static void end_render_result(BL::RenderEngine b_engine, BL::RenderResult b_rr, bool cancel = false)
@@ -270,7 +270,7 @@ void BlenderSession::do_write_update_render_tile(RenderTile& rtile, bool do_upda
 	int h = params.height;
 
 	/* get render result */
-	BL::RenderResult b_rr = begin_render_result(b_engine, x, y, w, h, b_rlay_name.c_str(), b_rview_id);
+	BL::RenderResult b_rr = begin_render_result(b_engine, x, y, w, h, b_rlay_name.c_str(), b_rview_name.c_str());
 
 	/* can happen if the intersected rectangle gives 0 width or height */
 	if (b_rr.ptr.data == NULL) {
@@ -336,9 +336,11 @@ void BlenderSession::render()
 	for(r.layers.begin(b_iter); b_iter != r.layers.end(); ++b_iter) {
 		b_rlay_name = b_iter->name();
 
-		for(r.views.begin(b_iterv), b_rview_id=0; b_iterv != r.views.end(); ++b_iterv, b_rview_id++) {
+		int b_rview_id=0;
+		for(r.views.begin(b_iterv); b_iterv != r.views.end(); ++b_iterv, ++b_rview_id) {
+			b_rview_name = b_iterv->name();
 			/* temporary render result to find needed passes */
-			BL::RenderResult b_rr = begin_render_result(b_engine, 0, 0, 1, 1, b_rlay_name.c_str(), -1);
+			BL::RenderResult b_rr = begin_render_result(b_engine, 0, 0, 1, 1, b_rlay_name.c_str(), NULL);
 			BL::RenderResult::layers_iterator b_single_rlay;
 			b_rr.layers.begin(b_single_rlay);
 
@@ -349,7 +351,7 @@ void BlenderSession::render()
 			}
 
 			/* set the current view */
-			b_engine.active_view_set(b_rview_id);
+			b_engine.active_view_set(b_rview_name.c_str());
 
 			BL::RenderLayer b_rlay = *b_single_rlay;
 

--- a/blender/intern/cycles/blender/blender_session.h
+++ b/blender/intern/cycles/blender/blender_session.h
@@ -85,7 +85,7 @@ public:
 	BL::SpaceView3D b_v3d;
 	BL::RegionView3D b_rv3d;
 	string b_rlay_name;
-	int b_rview_id;
+	string b_rview_name;
 
 	string last_status;
 	float last_progress;

--- a/blender/source/blender/imbuf/intern/openexr/openexr_api.cpp
+++ b/blender/source/blender/imbuf/intern/openexr/openexr_api.cpp
@@ -1093,13 +1093,14 @@ void IMB_exr_write_channels(void *handle)
 
 /* temporary function, used for FSA and Save Buffers */
 /* called once per tile * view */
-void IMB_exrtile_write_channels(void *handle, int partx, int party, int level, int view)
+void IMB_exrtile_write_channels(void *handle, int partx, int party, int level, const char *viewname)
 {
 	ExrHandle *data = (ExrHandle *)handle;
 	FrameBuffer frameBuffer;
 	ExrChannel *echan;
+	int view_id = imb_exr_get_multiView_id(*data->multiView, viewname);
 
-	exr_printf("\nIMB_exrtile_write_channels(view: %d)\n", view);
+	exr_printf("\nIMB_exrtile_write_channels(view: %s)\n", viewname);
 	exr_printf("%s %-6s %-22s \"%s\"\n", "p", "view", "name", "internal_name");
 	exr_printf("---------------------------------------------------------------------\n");
 
@@ -1107,7 +1108,7 @@ void IMB_exrtile_write_channels(void *handle, int partx, int party, int level, i
 
 		/* eventually we can make the parts' channels to include
 		   only the current view TODO */
-		if (view != echan->view_id)
+		if (view_id != echan->view_id)
 			continue;
 
 		exr_printf("%d %-6s %-22s \"%s\"\n",
@@ -1127,7 +1128,7 @@ void IMB_exrtile_write_channels(void *handle, int partx, int party, int level, i
 		                  );
 	}
 
-	TiledOutputPart out (*data->mpofile, view);
+	TiledOutputPart out (*data->mpofile, view_id);
 	out.setFrameBuffer(frameBuffer);
 
 	try {

--- a/blender/source/blender/imbuf/intern/openexr/openexr_multi.h
+++ b/blender/source/blender/imbuf/intern/openexr/openexr_multi.h
@@ -61,7 +61,7 @@ void    IMB_exr_set_channel(void *handle, const char *layname, const char *passn
 
 void    IMB_exr_read_channels(void *handle);
 void    IMB_exr_write_channels(void *handle);
-void    IMB_exrtile_write_channels(void *handle, int partx, int party, int level, int view);
+void    IMB_exrtile_write_channels(void *handle, int partx, int party, int level, const char *viewname);
 void    IMB_exrmultiview_write_channels(void *handle, int view_id);
 void    IMB_exr_clear_channels(void *handle);
 

--- a/blender/source/blender/imbuf/intern/openexr/openexr_stub.cpp
+++ b/blender/source/blender/imbuf/intern/openexr/openexr_stub.cpp
@@ -46,7 +46,7 @@ void    IMB_exr_set_channel         (void *handle, const char *layname, const ch
 
 void    IMB_exr_read_channels       (void *handle) { (void)handle; }
 void    IMB_exr_write_channels      (void *handle) { (void)handle; }
-void    IMB_exrtile_write_channels  (void *handle, int partx, int party, int level, int view) { (void)handle; (void)partx; (void)party; (void)level; (void)view }
+void    IMB_exrtile_write_channels  (void *handle, int partx, int party, int level, const char *viewname) { (void)handle; (void)partx; (void)party; (void)level; (void)viewname; }
 void    IMB_exrmultiview_write_channels  (void *handle) { (void)handle; }
 void    IMB_exr_clear_channels  (void *handle) { (void)handle; }
 

--- a/blender/source/blender/makesrna/intern/rna_render.c
+++ b/blender/source/blender/makesrna/intern/rna_render.c
@@ -385,8 +385,7 @@ static void rna_def_render_engine(BlenderRNA *brna)
 	prop = RNA_def_int(func, "h", 0, 0, INT_MAX, "Height", "", 0, INT_MAX);
 	RNA_def_property_flag(prop, PROP_REQUIRED);
 	RNA_def_string(func, "layer", "", 0, "Layer", "Single layer to get render result for");  /* NULL ok here */
-	prop = RNA_def_int(func, "view", 0, 0, INT_MAX, "View",
-	                   "index of the list of available views (not including disabled ones). -1 for all views", 0, INT_MAX);
+	RNA_def_string(func, "view", "", 0, "View", "Single view to get render result for");  /* NULL ok here */
 	RNA_def_property_flag(prop, PROP_REQUIRED);
 	prop = RNA_def_pointer(func, "result", "RenderResult", "Result", "");
 	RNA_def_function_return(func, prop);
@@ -405,8 +404,7 @@ static void rna_def_render_engine(BlenderRNA *brna)
 	RNA_def_function_return(func, prop);
 
 	func = RNA_def_function(srna, "active_view_set", "RE_engine_actview_set");
-	prop = RNA_def_int(func, "view", 0, 0, INT_MAX, "View",
-	                   "view index from the list of available views (not including disabled views)", 0, INT_MAX);
+	RNA_def_string(func, "view", "", 0, "View", "Set active view");  /* NULL ok here */
 	RNA_def_property_flag(prop, PROP_REQUIRED);
 
 	func = RNA_def_function(srna, "update_stats", "RE_engine_update_stats");

--- a/blender/source/blender/render/extern/include/RE_engine.h
+++ b/blender/source/blender/render/extern/include/RE_engine.h
@@ -119,11 +119,11 @@ void RE_engine_free(RenderEngine *engine);
 void RE_layer_load_from_file(struct RenderLayer *layer, struct ReportList *reports, const char *filename, int x, int y);
 void RE_result_load_from_file(struct RenderResult *result, struct ReportList *reports, const char *filename);
 
-struct RenderResult *RE_engine_begin_result(RenderEngine *engine, int x, int y, int w, int h, const char *layername, int view);
+struct RenderResult *RE_engine_begin_result(RenderEngine *engine, int x, int y, int w, int h, const char *layername, const char * viewname);
 void RE_engine_update_result(RenderEngine *engine, struct RenderResult *result);
 void RE_engine_end_result(RenderEngine *engine, struct RenderResult *result, int cancel);
 
-void RE_engine_actview_set(RenderEngine *engine, int view);
+void RE_engine_actview_set(RenderEngine *engine, const char *viewname);
 
 int RE_engine_test_break(RenderEngine *engine);
 void RE_engine_update_stats(RenderEngine *engine, const char *stats, const char *info);

--- a/blender/source/blender/render/intern/include/render_result.h
+++ b/blender/source/blender/render/intern/include/render_result.h
@@ -38,6 +38,7 @@
 #define RR_USE_EXR		1
 
 #define RR_ALL_LAYERS	NULL
+#define RR_ALL_VIEWS	NULL
 
 struct ImBuf;
 struct ListBase;
@@ -53,9 +54,9 @@ struct ColorManagedViewSettings;
 /* New */
 
 struct RenderResult *render_result_new(struct Render *re,
-	struct rcti *partrct, int crop, int savebuffers, const char *layername, int view);
+	struct rcti *partrct, int crop, int savebuffers, const char *layername, const char *viewname);
 struct RenderResult *render_result_new_full_sample(struct Render *re,
-	struct ListBase *lb, struct rcti *partrct, int crop, int savebuffers, int view);
+	struct ListBase *lb, struct rcti *partrct, int crop, int savebuffers, const char  *viewname);
 
 struct RenderResult *render_result_new_from_exr(void *exrhandle, const char *colorspace, int predivide, int rectx, int recty);
 
@@ -78,7 +79,7 @@ void render_result_single_layer_end(struct Render *re);
 void render_result_exr_file_begin(struct Render *re);
 void render_result_exr_file_end(struct Render *re);
 
-void render_result_exr_file_merge(struct RenderResult *rr, struct RenderResult *rrpart, int view);
+void render_result_exr_file_merge(struct RenderResult *rr, struct RenderResult *rrpart, const char *viewname);
 
 void render_result_exr_file_path(struct Scene *scene, const char *layname, int sample, char *filepath);
 int render_result_exr_file_read(struct Render *re, int sample);

--- a/blender/source/blender/render/intern/include/render_types.h
+++ b/blender/source/blender/render/intern/include/render_types.h
@@ -273,6 +273,8 @@ struct Render
 	struct ImagePool *pool;
 
 	int actview;
+
+	char *viewname;
 };
 
 /* ------------------------------------------------------------------------- */

--- a/blender/source/blender/render/intern/source/external_engine.c
+++ b/blender/source/blender/render/intern/source/external_engine.c
@@ -183,7 +183,7 @@ static RenderPart *get_part_from_result(Render *re, RenderResult *result)
 	return NULL;
 }
 
-RenderResult *RE_engine_begin_result(RenderEngine *engine, int x, int y, int w, int h, const char *layername, int view)
+RenderResult *RE_engine_begin_result(RenderEngine *engine, int x, int y, int w, int h, const char *layername, const char *viewname)
 {
 	Render *re = engine->re;
 	RenderResult *result;
@@ -206,7 +206,7 @@ RenderResult *RE_engine_begin_result(RenderEngine *engine, int x, int y, int w, 
 	disprect.ymin = y;
 	disprect.ymax = y + h;
 
-	result = render_result_new(re, &disprect, 0, RR_USE_MEM, layername, view);
+	result = render_result_new(re, &disprect, 0, RR_USE_MEM, layername, viewname);
 
 	/* todo: make this thread safe */
 
@@ -257,7 +257,7 @@ void RE_engine_end_result(RenderEngine *engine, RenderResult *result, int cancel
 			pa->status = PART_STATUS_READY;
 
 		if (re->result->do_exr_tile)
-			render_result_exr_file_merge(re->result, result, re->actview);
+			render_result_exr_file_merge(re->result, result, re->viewname);
 		else if (!(re->test_break(re->tbh) && (re->r.scemode & R_BUTS_PREVIEW)))
 			render_result_merge(re->result, result);
 
@@ -344,10 +344,10 @@ void RE_engine_report(RenderEngine *engine, int type, const char *msg)
 		BKE_report(engine->reports, type, msg);
 }
 
-void RE_engine_actview_set(RenderEngine *engine, int view)
+void RE_engine_actview_set(RenderEngine *engine, const char *viewname)
 {
 	Render *re = engine->re;
-	re->actview = view;
+	re->viewname = viewname;
 }
 
 void RE_engine_get_current_tiles(Render *re, int *total_tiles_r, rcti **tiles_r)
@@ -450,7 +450,7 @@ int RE_engine_render(Render *re, int do_all)
 			render_result_free(re->result);
 
 		savebuffers = (re->r.scemode & R_EXR_TILE_FILE) ? RR_USE_EXR : RR_USE_MEM;
-		re->result = render_result_new(re, &re->disprect, 0, savebuffers, RR_ALL_LAYERS, -1);
+		re->result = render_result_new(re, &re->disprect, 0, savebuffers, RR_ALL_LAYERS, RR_ALL_VIEWS);
 	}
 	BLI_rw_mutex_unlock(&re->resultmutex);
 

--- a/blender/source/blender/render/intern/source/initrender.c
+++ b/blender/source/blender/render/intern/source/initrender.c
@@ -446,14 +446,14 @@ void make_sample_tables(Render *re)
 struct Object *RE_GetViewCamera(Render *re)
 {
 	RenderView *rv;
-	int actview = MIN2(re->actview, BLI_countlist(&re->result->views)-1);
-	int nr = 0;
 
-	for (rv=(RenderView *)re->result->views.first; rv; rv=rv->next, nr++) {
-		if (actview == nr)
-			return rv->camera;
+	if (!re || !re->viewname)
+		return RE_GetCamera(re);
+
+	rv = BLI_findstring(&re->result->views, re->viewname, offsetof(RenderView, name));
+	if (rv && rv->camera) {
+		return rv->camera;
 	}
-
 	return RE_GetCamera(re);
 }
 


### PR DESCRIPTION
This is a one commit, and one question pull request.
@brechtvl I'm not sure whether to:

1) get rid of Render.actview entirely (and use only Render.viewname everywhere)
2) keep a mixed approach (as this pull is doing) - extended to other functions that could also work with string instead of int)
3) forget this patch and use "const char*" for the views only for the RNA/api function you suggested.

I'm inclined towards 2.
