### PR TITLE
Fix compile error: ‘StereoViews’ has not been declared

### DIFF
--- a/blender/source/blender/blenkernel/BKE_camera.h
+++ b/blender/source/blender/blenkernel/BKE_camera.h
@@ -36,6 +36,7 @@
 extern "C" {
 #endif
 
+#include "DNA_scene_types.h"
 #include "DNA_vec_types.h"
 
 struct Camera;


### PR DESCRIPTION
This patch fixes compile error:
source/blender/blenkernel/BKE_camera.h:123:95: error: ‘StereoViews’ has not been declared
source/blender/blenkernel/BKE_camera.h:124:6: error: use of enum ‘StereoViews’ without previous declaration

I reported the error on IRC long time ago but did not send the patch right away and then it got forgotten. The problem is still present, so I'm sending it now.
